### PR TITLE
Refactor : createSaga 함수 생성

### DIFF
--- a/src/store/sagas/todoListSaga.ts
+++ b/src/store/sagas/todoListSaga.ts
@@ -1,6 +1,4 @@
-import { AxiosError } from 'axios';
-import { put, takeLatest, call, fork, all } from 'redux-saga/effects';
-import { PayloadAction } from '@reduxjs/toolkit';
+import { takeLatest, fork, all } from 'redux-saga/effects';
 
 import { getTodos, postCheckTodo } from 'api/todos';
 import { IPostCheckTodoResponse } from 'api/types/response';
@@ -13,31 +11,23 @@ import {
   requestTodosFailure,
   requestTodosSuccess,
 } from 'store/slice/todoListSlice';
+import { createSaga } from 'store/utils/fetchEntity';
 
-function* postCheckTodosList({
-  payload,
-}: PayloadAction<IRequestCheckTodoPayload>) {
-  try {
-    const response: IPostCheckTodoResponse = yield call(postCheckTodo, payload);
+const postCheckTodosList = createSaga<
+  IRequestCheckTodoPayload,
+  IPostCheckTodoResponse
+>({
+  entity: { success: requestCheckTodoSuccess, fail: requestCheckTodoFailure },
+  api: postCheckTodo,
+});
 
-    yield put(requestCheckTodoSuccess(response));
-  } catch (e) {
-    yield put(requestCheckTodoFailure((e as AxiosError).response?.data));
-  }
-}
+const getTodosList = createSaga<null, ITodos>({
+  entity: { success: requestTodosSuccess, fail: requestTodosFailure },
+  api: getTodos,
+});
 
 function* watchPostCheckTodosList() {
   yield takeLatest(requestCheckTodo.type, postCheckTodosList);
-}
-
-function* getTodosList() {
-  try {
-    const response: ITodos = yield call(getTodos);
-
-    yield put(requestTodosSuccess(response));
-  } catch (e) {
-    yield put(requestTodosFailure((e as AxiosError).response?.data));
-  }
 }
 
 function* watchGetTodosList() {

--- a/src/store/utils/fetchEntity.ts
+++ b/src/store/utils/fetchEntity.ts
@@ -1,0 +1,28 @@
+import { ActionCreatorWithPayload, PayloadAction } from '@reduxjs/toolkit';
+import { AxiosError } from 'axios';
+import { call, put } from 'redux-saga/effects';
+
+interface Entity<Success> {
+  entity: {
+    success: ActionCreatorWithPayload<Success>;
+    fail: ActionCreatorWithPayload<AxiosError>;
+  };
+  api: any;
+}
+
+export const createSaga = <Start, Success>({
+  entity,
+  api,
+}: Entity<Success>) => {
+  const { success, fail } = entity;
+
+  return function* (action: PayloadAction<Start>) {
+    try {
+      const response: Success = yield call(api, action.payload);
+
+      yield put(success(response));
+    } catch (error) {
+      yield put(fail((error as AxiosError).response?.data));
+    }
+  };
+};


### PR DESCRIPTION
- redux saga 구현부의 반복되는 코드를 줄이기 위해 반복되는 패턴을 재사용할 수 있는 fetchEntity 함수를 만들었습니다

## 변경된 코드
### createSaga
```ts
interface Entity<Success> {
  entity: {
    success: ActionCreatorWithPayload<Success>;
    fail: ActionCreatorWithPayload<AxiosError>;
  };
  api: any;
}

export const createSaga = <Start, Success>({
  entity,
  api,
}: Entity<Success>) => {
  const { success, fail } = entity;

  return function* (action: PayloadAction<Start>) {
    try {
      const response: Success = yield call(api, action.payload);

      yield put(success(response));
    } catch (error) {
      yield put(fail((error as AxiosError).response?.data));
    }
  };
};
```

### createSaga 사용 코드
```js
const postCheckTodosList = createSaga<
  IRequestCheckTodoPayload,
  IPostCheckTodoResponse
>({
  entity: { success: requestCheckTodoSuccess, fail: requestCheckTodoFailure },
  api: postCheckTodo,
});

const getTodosList = createSaga<null, ITodos>({
  entity: { success: requestTodosSuccess, fail: requestTodosFailure },
  api: getTodos,
});

function* watchPostCheckTodosList() {
  yield takeLatest(requestCheckTodo.type, postCheckTodosList);
}

function* watchGetTodosList() {
  yield takeLatest(requestTodos.type, getTodosList);
}

function* todoListSaga() {
  yield all([fork(watchGetTodosList), fork(watchPostCheckTodosList)]);
}

```

## 코드 작성을 위해 참고한 글
- [Redux Toolkit과 자체 util 함수로 Redux+Saga 타이핑 줄이기](https://maxkim-j.github.io/posts/how-to-minimize-redux-saga-typing)
- [redux-saga-real-world-example](https://github.com/redux-saga/redux-saga/blob/master/examples/real-world/sagas/index.js)